### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,38 @@ In laravel 5.2.23 and above you can use the fluent syntax:
 NewsItem::where('name->en', 'Name in English')->get();
 ```
 
+### Automatically display the right translation when displaying model
+
+Many times models using `HasTranslation` trait may be directly returned as response content.
+In this scenario, and similar ones, the `toArray()` method on `Model` class is called under the hood to serialize your model; it accesses directly the $attributes field to perform the serialization, bypassing the translatable feature (which is based on accessors and mutators) and returning the text representation of the stored JSON instead of the translated value.
+
+The best way to make your model automatically return translated fields is to wrap `Spatie\Translatable\HasTranslations` trait into a custom trait which overrides the `toArray()` method to automatically replace all translatable fields content with their translated value, like in the following example, and use it instead of the default one.
+
+``` php
+namespace App\Traits;
+
+use Spatie\Translatable\HasTranslations as BaseHasTranslations;
+
+trait HasTranslations
+{
+    use BaseHasTranslations;
+
+    /**
+     * Convert the model instance to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $attributes = parent::toArray();
+        foreach ($this->getTranslatableAttributes() as $field) {
+            $attributes[$field] = $this->getTranslation($field, \App::getLocale());
+        }
+        return $attributes;
+    }
+}
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
Added a suggestion in README on how to tackle the problem when returning models using translatable.
By default JSON value of the fields are returned, with this fix the translated values for the current locale will be returned.